### PR TITLE
Upgrade focus-group dep to 0.3.1

### DIFF
--- a/lib/createManager.js
+++ b/lib/createManager.js
@@ -5,8 +5,12 @@ function Manager(options) {
 
   var focusGroupOptions = {
     wrap: true,
-    forwardArrows: ['down', 'right'],
-    backArrows: ['up', 'left'],
+    keybindings: {
+      // down, right
+      next: [{ keyCode: 40 }, { keyCode: 39 }],
+      // up, left
+      prev: [{ keyCode: 38 }, { keyCode: 37 }],
+    },
     stringSearch: options.letterNavigation,
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aria-tabpanel",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2091,9 +2091,9 @@
       }
     },
     "focus-group": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/focus-group/-/focus-group-0.2.3.tgz",
-      "integrity": "sha1-lWoRJKFJX30PTy3UxhJQKr9KRfk="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/focus-group/-/focus-group-0.3.1.tgz",
+      "integrity": "sha1-4PMu2GsNq91v/OvfiY7LMuR/7c4="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "create-react-class": "^15.6.2",
-    "focus-group": "^0.2.2",
+    "focus-group": "^0.3.1",
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
**Summary**
In working with a project using both `react-aria-menubutton` and `react-aria-tabpanel` (awesome libs by the way - thank you!!), I noticed each depends on a different version of `focus-group`. For bundling purposes, this is problematic (if only `0.3.1` is included, the `options` API change introduced in `0.3.0`, causes left/right navigation to be broken), so this PR aims to update `focus-group` to latest (`0.3.1`) and fix compatibility. 

**Test Plan**
Confirmed left/right navigation is broken with `0.3.1`
Confirmed left/right navigation is fixed with changes to `lib/createManager.js`
