### PR TITLE
Fixed deprecation warning.

### DIFF
--- a/lib/Wrapper.js
+++ b/lib/Wrapper.js
@@ -29,12 +29,14 @@ module.exports = createReactClass({
     return { atpManager: this.manager };
   },
 
-  componentWillMount: function() {
+  getInitialState: function() {
     this.manager = createManager({
       onChange: this.props.onChange,
       activeTabId: this.props.activeTabId,
       letterNavigation: this.props.letterNavigation,
     });
+
+    return null
   },
 
   componentWillUnmount: function() {
@@ -47,7 +49,7 @@ module.exports = createReactClass({
 
   componentDidUpdate: function(prevProps) {
     var updateActiveTab = (prevProps.activeTabId === this.manager.activeTabId) && (prevProps.activeTabId !== this.props.activeTabId);
-    
+
     if (updateActiveTab) {
       this.manager.activateTab(this.props.activeTabId);
     }


### PR DESCRIPTION
Since React 16.3, use of `componentWillMount` gives a deprecation warning. Creating the manager in `getInitialState` prevents the warning.

Tested manually with React 16.3.2 and 0.14.10.
